### PR TITLE
Fix MicroSeries bitwise ops

### DIFF
--- a/microdf/generic.py
+++ b/microdf/generic.py
@@ -320,6 +320,12 @@ class MicroSeries(pd.Series):
     def __pow__(self, other):
         return MicroSeries(super().__pow__(other), weights=self.weights)
 
+    def __and__(self, other):
+        return MicroSeries(super().__and__(other), weights=self.weights)
+
+    def __or__(self, other):
+        return MicroSeries(super().__or__(other), weights=self.weights)
+
     # comparators
 
     def __lt__(self, other):

--- a/microdf/tests/test_generic.py
+++ b/microdf/tests/test_generic.py
@@ -206,3 +206,14 @@ def test_value_subset():
     d = mdf.MicroDataFrame({"x": [1, 2, 3], "y": [1, 2, 2]}, weights=[4, 5, 6])
     d2 = d[d.y > 1]
     assert d2.y.shape == d2.weights.shape
+
+
+def test_bitwise_ops_return_microseries():
+    s1 = mdf.MicroSeries([True, False, True], weights=[1, 2, 3])
+    s2 = mdf.MicroSeries([False, False, True], weights=[1, 2, 3])
+    and_result = s1 & s2
+    or_result = s1 | s2
+    assert isinstance(and_result, mdf.MicroSeries)
+    assert isinstance(or_result, mdf.MicroSeries)
+    assert and_result.equals(mdf.MicroSeries([False, False, True], weights=[1, 2, 3]))
+    assert or_result.equals(mdf.MicroSeries([True, False, True], weights=[1, 2, 3]))


### PR DESCRIPTION
## Summary
- preserve MicroSeries type when using `&` and `|`
- test bitwise operators return MicroSeries

## Testing
- `pytest microdf/tests/test_generic.py::test_bitwise_ops_return_microseries -q`
- `pytest -q` *(fails: test_read_stata_zip, test_quantile_pct_chg_plot)*

------
https://chatgpt.com/codex/tasks/task_e_686d7d039a488321a1f192bd63f8c7df