### PR TITLE
Fix merge() method to return MicroDataFrame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@
 - All files must end with a newline character
 - **ALWAYS run `make format` before committing** - this will auto-fix most style issues
 - Run `make lint` after formatting to check if there are any remaining issues
+- **IMPORTANT**: `make format` will fail if there are lines over 79 characters that black can't fix (usually in strings/comments). You must manually break these lines.
 
 ## Changelog Requirements
 - Every PR must include a `changelog_entry.yaml` file at the root

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,14 @@
 - The file must not be empty and must end with a newline
 
 ## Testing
-- Run tests with: `python3 -m pytest microdf/tests/ -v`
+- Install development dependencies first: `make install` or `pip install -e ".[dev]"`
+- Run all tests: `make test` or `pytest -q --cov=microdf --cov-report=xml`
+- Run specific test: `python3 -m pytest microdf/tests/test_microseries_dataframe.py::test_df_init -v`
 - Ensure all tests pass before creating a PR
+- If tests fail, check for:
+  - Missing `_link_all_weights()` calls after setting weights
+  - Proper handling of both array and string arguments in `set_weights()`
+  - Deprecation warnings properly configured with `stacklevel=2`
 
 ## Pull Request Process
 1. Create a feature branch from master
@@ -34,3 +40,24 @@
 ## Documentation
 - Documentation notebooks are in `docs/` directory
 - When removing functionality, consider impact on documentation examples
+
+## Common CI Failures and Solutions
+
+### Test Failures
+1. **set_weights() with string not working**: Ensure `_link_all_weights()` is called for both string and array cases
+2. **Deprecation warnings in tests**: Import warnings and suppress with `warnings.simplefilter("ignore", DeprecationWarning)` in test setup
+3. **MicroSeries not properly linked**: Check that all DataFrame operations call `_link_all_weights()` after modifying structure
+
+### Linting Failures
+1. **Line length**: Run `make format` to auto-fix most issues
+2. **Import order**: `isort` is configured to work with black, run `make format`
+3. **Docstring formatting**: `docformatter` enforces 79-char wrapping, run `make format`
+4. **File endings**: Ensure all files end with a newline
+
+### Before Pushing
+Always run these commands locally:
+```bash
+make format  # Auto-fix style issues
+make lint    # Check for remaining issues
+make test    # Run all tests
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 ## Code Style
 - All files must end with a newline character
-- Run `make lint` before committing to catch style issues
+- **ALWAYS run `make format` before committing** - this will auto-fix most style issues
+- Run `make lint` after formatting to check if there are any remaining issues
 
 ## Changelog Requirements
 - Every PR must include a `changelog_entry.yaml` file at the root
@@ -55,9 +56,11 @@
 4. **File endings**: Ensure all files end with a newline
 
 ### Before Pushing
-Always run these commands locally:
+**CRITICAL: Always run these commands locally before pushing:**
 ```bash
-make format  # Auto-fix style issues
-make lint    # Check for remaining issues
+make format  # Auto-fix style issues (ALWAYS RUN THIS FIRST!)
+make lint    # Check for remaining issues (should pass after format)
 make test    # Run all tests
 ```
+
+If CI fails with linting errors, it's almost always because `make format` wasn't run.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,13 @@ format:
 	isort --profile black microdf/
 	docformatter --wrap-summaries 79 --wrap-descriptions 79 --in-place --recursive microdf/
 	black . -l 79
+	@echo "Checking for lines that are too long (E501)..."
+	@if flake8 . --select=E501 --max-line-length=79 2>/dev/null | grep -q .; then \
+		echo "WARNING: The following lines are too long and must be manually fixed:"; \
+		flake8 . --select=E501 --max-line-length=79; \
+		echo "Please manually break these long strings/comments to be under 79 characters."; \
+		exit 1; \
+	fi
 
 lint:
 	linecheck .

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,4 +2,7 @@
   changes:
     fixed:
     - MicroDataFrame.merge() now works correctly by implementing inplace support for the drop() method
-    - merge() now returns a MicroDataFrame instead of a regular DataFrame
+    - merge() now returns a MicroDataFrame instead of a regular DataFrame (Fixes #194)
+    added:
+    - __getattr__ method to MicroDataFrame for intuitive column access via dot notation (Fixes #220)
+    - Full pandas argument support to drop() and merge() methods (Addresses #212)

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - MicroDataFrame.merge() now works correctly by implementing inplace support for the drop() method
+    - merge() now returns a MicroDataFrame instead of a regular DataFrame

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -8,3 +8,6 @@
     - __getattr__ method to MicroDataFrame for intuitive column access via dot notation (Fixes #220)
     - Full pandas argument support to drop() and merge() methods (Addresses #212)
     - nullify_weights() method to both MicroDataFrame and MicroSeries to set all weights to 1 (Fixes #176)
+    - Test coverage for set_weights() with string column name argument
+    deprecated:
+    - set_weight_col() method - use set_weights() with a string argument instead (Fixes #208)

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -6,3 +6,4 @@
     added:
     - __getattr__ method to MicroDataFrame for intuitive column access via dot notation (Fixes #220)
     - Full pandas argument support to drop() and merge() methods (Addresses #212)
+    - nullify_weights() method to both MicroDataFrame and MicroSeries to set all weights to 1 (Fixes #176)

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -3,6 +3,7 @@
     fixed:
     - MicroDataFrame.merge() now works correctly by implementing inplace support for the drop() method
     - merge() now returns a MicroDataFrame instead of a regular DataFrame (Fixes #194)
+    - MicroDataFrame aggregation functions now skip non-numeric columns instead of raising errors (Fixes #213)
     added:
     - __getattr__ method to MicroDataFrame for intuitive column access via dot notation (Fixes #220)
     - Full pandas argument support to drop() and merge() methods (Addresses #212)

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -242,8 +242,8 @@ class MicroDataFrame(pd.DataFrame):
         import warnings
 
         warnings.warn(
-            "set_weight_col is deprecated and will be removed in a future version. "
-            "Use set_weights(column_name) instead.",
+            "set_weight_col is deprecated and will be removed in a "
+            "future version. Use set_weights(column_name) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -465,8 +465,8 @@ class MicroDataFrame(pd.DataFrame):
             validate=validate,
         )
 
-        # For inner join, both dataframes must have the same weights on matching rows
-        # For now, we'll use the left dataframe's weights
+        # For inner join, both dataframes must have the same weights on
+        # matching rows. For now, we'll use the left dataframe's weights.
         # This is a simplification and may need more sophisticated handling
         return MicroDataFrame(res, weights=self.weights)
 

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -215,6 +215,15 @@ class MicroDataFrame(pd.DataFrame):
         self.weights_col = column
         self._link_all_weights()
 
+    def nullify_weights(self) -> None:
+        """Set all weights to 1, effectively making the DataFrame unweighted.
+        
+        This is useful for comparing weighted and unweighted statistics or
+        when you want to temporarily ignore weights.
+        """
+        self.weights = np.ones(len(self))
+        self._link_all_weights()
+
     def __getitem__(
         self, key: Union[str, List]
     ) -> Union[pd.Series, pd.DataFrame]:

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -48,7 +48,9 @@ class MicroDataFrame(pd.DataFrame):
             for col in self.columns:
                 if pd.api.types.is_numeric_dtype(self[col]):
                     try:
-                        results[col] = getattr(self[col], name)(*args, **kwargs)
+                        results[col] = getattr(self[col], name)(
+                            *args, **kwargs
+                        )
                     except Exception:
                         # Skip columns that can't be aggregated
                         pass
@@ -75,7 +77,7 @@ class MicroDataFrame(pd.DataFrame):
                     except Exception:
                         # Skip columns that can't be aggregated
                         pass
-            
+
             if results:
                 df = pd.DataFrame(results)
                 df.index = columns
@@ -110,7 +112,7 @@ class MicroDataFrame(pd.DataFrame):
                         except Exception:
                             # Skip columns that can't be aggregated
                             pass
-                
+
                 if results:
                     df = pd.DataFrame(results)
                     df.index = columns
@@ -123,7 +125,9 @@ class MicroDataFrame(pd.DataFrame):
                 for col in self.columns:
                     if pd.api.types.is_numeric_dtype(self[col]):
                         try:
-                            results[col] = getattr(self[col], name)(*args, **kwargs)
+                            results[col] = getattr(self[col], name)(
+                                *args, **kwargs
+                            )
                         except Exception:
                             # Skip columns that can't be aggregated
                             pass
@@ -236,13 +240,14 @@ class MicroDataFrame(pd.DataFrame):
         :type column: str
         """
         import warnings
+
         warnings.warn(
             "set_weight_col is deprecated and will be removed in a future version. "
             "Use set_weights(column_name) instead.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
-        
+
         if preserve_old and self.weights_col is not None:
             self["old_" + self.weights_col] = self.weights
 
@@ -459,7 +464,7 @@ class MicroDataFrame(pd.DataFrame):
             indicator=indicator,
             validate=validate,
         )
-        
+
         # For inner join, both dataframes must have the same weights on matching rows
         # For now, we'll use the left dataframe's weights
         # This is a simplification and may need more sophisticated handling
@@ -647,7 +652,8 @@ class MicroDataFrameGroupBy(pd.core.groupby.generic.DataFrameGroupBy):
         self.columns.remove("__tmp_weights")
         # Filter to only numeric columns
         self.numeric_columns = [
-            col for col in self.columns 
+            col
+            for col in self.columns
             if pd.api.types.is_numeric_dtype(self.obj[col])
         ]
         for fn_name in MicroSeries.SCALAR_FUNCTIONS:
@@ -663,7 +669,11 @@ class MicroDataFrameGroupBy(pd.core.groupby.generic.DataFrameGroupBy):
                         except Exception:
                             # Skip columns that can't be aggregated
                             pass
-                    return MicroDataFrame(results) if results else MicroDataFrame()
+                    return (
+                        MicroDataFrame(results)
+                        if results
+                        else MicroDataFrame()
+                    )
 
                 return fn
 
@@ -681,7 +691,11 @@ class MicroDataFrameGroupBy(pd.core.groupby.generic.DataFrameGroupBy):
                         except Exception:
                             # Skip columns that can't be aggregated
                             pass
-                    return MicroDataFrame(results) if results else MicroDataFrame()
+                    return (
+                        MicroDataFrame(results)
+                        if results
+                        else MicroDataFrame()
+                    )
 
                 return fn
 

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -225,11 +225,23 @@ class MicroDataFrame(pd.DataFrame):
         """Sets the weights for the MicroDataFrame by specifying the name of
         the weight column.
 
-        :param weights: Array of weights.
+        .. deprecated:: 1.0.2
+            Use :meth:`set_weights` with a string argument instead.
+            This method will be removed in a future version.
+
+        :param column: Name of the column to use as weights.
         :param preserve_old: If True, keeps the old weights as a column when
             new weights are provided.
-        :type weights: np.array
+        :type column: str
         """
+        import warnings
+        warnings.warn(
+            "set_weight_col is deprecated and will be removed in a future version. "
+            "Use set_weights(column_name) instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        
         if preserve_old and self.weights_col is not None:
             self["old_" + self.weights_col] = self.weights
 

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -252,9 +252,9 @@ class MicroDataFrame(pd.DataFrame):
 
     def nullify_weights(self) -> None:
         """Set all weights to 1, effectively making the DataFrame unweighted.
-        
-        This is useful for comparing weighted and unweighted statistics or
-        when you want to temporarily ignore weights.
+
+        This is useful for comparing weighted and unweighted statistics or when
+        you want to temporarily ignore weights.
         """
         self.weights = np.ones(len(self))
         self._link_all_weights()
@@ -369,7 +369,8 @@ class MicroDataFrame(pd.DataFrame):
             equivalent to index=labels).
         :param columns: Alternative to specifying axis (labels, axis=1 is
             equivalent to columns=labels).
-        :param level: For MultiIndex, level from which the labels will be removed.
+        :param level: For MultiIndex, level from which the labels will be
+            removed.
         :param inplace: If False, return a copy. Otherwise, do operation
             inplace and return None.
         :param errors: If 'ignore', suppress error and only existing labels are
@@ -420,20 +421,27 @@ class MicroDataFrame(pd.DataFrame):
     ):
         """Merge DataFrame or named Series objects with a database-style join.
 
-        This method overrides pandas DataFrame.merge() to return a MicroDataFrame.
+        This method overrides pandas DataFrame.merge() to return a
+        MicroDataFrame.
 
         :param right: Object to merge with.
         :param how: Type of merge to be performed.
         :param on: Column or index level names to join on.
-        :param left_on: Column or index level names to join on in the left DataFrame.
-        :param right_on: Column or index level names to join on in the right DataFrame.
-        :param left_index: Use the index from the left DataFrame as the join key(s).
-        :param right_index: Use the index from the right DataFrame as the join key(s).
-        :param sort: Sort the join keys lexicographically in the result DataFrame.
-        :param suffixes: A length-2 sequence where each element is optionally a string
-            indicating the suffix to add to overlapping column names.
+        :param left_on: Column or index level names to join on in the left
+            DataFrame.
+        :param right_on: Column or index level names to join on in the right
+            DataFrame.
+        :param left_index: Use the index from the left DataFrame as the join
+            key(s).
+        :param right_index: Use the index from the right DataFrame as the join
+            key(s).
+        :param sort: Sort the join keys lexicographically in the result
+            DataFrame.
+        :param suffixes: A length-2 sequence where each element is optionally a
+            string indicating the suffix to add to overlapping column names.
         :param copy: If False, avoid copy if possible.
-        :param indicator: If True, adds a column to output DataFrame called "_merge".
+        :param indicator: If True, adds a column to output DataFrame called
+            "_merge".
         :param validate: If specified, checks if merge is of specified type.
         :return: MicroDataFrame with merged data.
         """
@@ -459,12 +467,13 @@ class MicroDataFrame(pd.DataFrame):
 
     def __getattr__(self, name):
         """Allow accessing columns as attributes (e.g., df.column_name).
-        
+
         This enables more intuitive column access while preserving MicroSeries
         functionality when accessing columns.
-        
+
         :param name: Attribute name to access
-        :return: MicroSeries if the attribute is a column, otherwise delegates to parent
+        :return: MicroSeries if the attribute is a column, otherwise delegates
+            to parent
         """
         if name in self.columns:
             return self[name]

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -207,6 +207,7 @@ class MicroDataFrame(pd.DataFrame):
         if isinstance(weights, str):
             self.weights_col = weights
             self.weights = pd.Series(self[weights], dtype=float)
+            self._link_all_weights()
         elif weights is not None:
             if len(weights) != len(self):
                 raise ValueError(

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -413,6 +413,19 @@ class MicroDataFrame(pd.DataFrame):
         # This is a simplification and may need more sophisticated handling
         return MicroDataFrame(res, weights=self.weights)
 
+    def __getattr__(self, name):
+        """Allow accessing columns as attributes (e.g., df.column_name).
+        
+        This enables more intuitive column access while preserving MicroSeries
+        functionality when accessing columns.
+        
+        :param name: Attribute name to access
+        :return: MicroSeries if the attribute is a column, otherwise delegates to parent
+        """
+        if name in self.columns:
+            return self[name]
+        return super().__getattr__(name)
+
     def equals(self, other: "MicroDataFrame") -> bool:
         equal_values = super().equals(other)
         equal_weights = self.weights.equals(other.weights)

--- a/microdf/microseries.py
+++ b/microdf/microseries.py
@@ -68,9 +68,9 @@ class MicroSeries(pd.Series):
 
     def nullify_weights(self) -> None:
         """Set all weights to 1, effectively making the Series unweighted.
-        
-        This is useful for comparing weighted and unweighted statistics or
-        when you want to temporarily ignore weights.
+
+        This is useful for comparing weighted and unweighted statistics or when
+        you want to temporarily ignore weights.
         """
         self.weights = pd.Series(np.ones(len(self)), dtype=float)
 

--- a/microdf/microseries.py
+++ b/microdf/microseries.py
@@ -66,6 +66,14 @@ class MicroSeries(pd.Series):
 
             self.weights = pd.Series(weights, dtype=float)
 
+    def nullify_weights(self) -> None:
+        """Set all weights to 1, effectively making the Series unweighted.
+        
+        This is useful for comparing weighted and unweighted statistics or
+        when you want to temporarily ignore weights.
+        """
+        self.weights = pd.Series(np.ones(len(self)), dtype=float)
+
     @vector_function
     def weight(self) -> pd.Series:
         """Calculates the weighted value of the MicroSeries.

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -22,6 +22,14 @@ def test_df_init() -> None:
     df["w"] = w
     df.set_weight_col("w")
     assert df.a.mean() == np.average(arr, weights=w)
+    
+    # Test set_weights with string (column name)
+    df2 = mdf.MicroDataFrame()
+    df2["a"] = arr
+    df2["w"] = w
+    df2.set_weights("w")  # Using string column name instead of set_weight_col
+    assert df2.a.mean() == np.average(arr, weights=w)
+    assert np.array_equal(df2.weights.values, w)
 
 
 def test_handles_empty_index() -> None:

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -22,7 +22,7 @@ def test_df_init() -> None:
     df["w"] = w
     df.set_weight_col("w")
     assert df.a.mean() == np.average(arr, weights=w)
-    
+
     # Test set_weights with string (column name)
     df2 = mdf.MicroDataFrame()
     df2["a"] = arr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.0.1"
 description = "Weighted pandas DataFrames and Series for survey microdata"
 readme = "README.md"
 authors = [
-    { name = "Max Ghenis", email = "max@ubicenter.org" }
+    { name = "Max Ghenis", email = "max@policyengine.org" }
 ]
 license = { text = "MIT" }
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
This PR addresses multiple open issues by implementing missing functionality and fixing bugs in MicroDataFrame:
- Implements `merge()` method that properly returns a MicroDataFrame
- Adds `drop()` method with full inplace support
- Adds `__getattr__` method for intuitive column access
- Adds `nullify_weights()` method to temporarily ignore weights
- Fixes aggregation functions to skip non-numeric columns
- Deprecates redundant `set_weight_col()` method

## Changes
1. **Added `drop()` method**: Required for merge operations, supports all pandas DataFrame.drop() parameters including inplace
2. **Added `merge()` method**: Overrides pandas merge to return MicroDataFrame with preserved weights
3. **Added `__getattr__` method**: Allows accessing columns as attributes (e.g., `df.column_name`)
4. **Added `nullify_weights()` method**: Sets all weights to 1 for both MicroDataFrame and MicroSeries
5. **Fixed aggregation functions**: Now skip non-numeric columns instead of raising errors
6. **Deprecated `set_weight_col()`**: Users should use `set_weights(column_name)` instead
7. **Added test coverage**: For `set_weights()` with string column name argument

## Issues Fixed
- Fixes #194: MicroDataFrame.merge() now returns a MicroDataFrame
- Fixes #220: Added __getattr__ override to MicroDataFrame for dot notation column access
- Fixes #176: Added nullify_weights() method to set all weights to 1
- Fixes #213: MicroDataFrame aggregation functions now skip non-numeric columns
- Fixes #208: Deprecated set_weight_col() in favor of set_weights()
- Addresses #212: Added full pandas argument support to drop() and merge() methods

## Test plan
- [ ] Existing tests pass
- [ ] Merge operations return MicroDataFrame instances
- [ ] Drop operations work both with and without inplace=True
- [ ] Weights are preserved correctly
- [ ] Column access via dot notation works (e.g., df.column_name)
- [ ] nullify_weights() sets all weights to 1
- [ ] Aggregation functions skip non-numeric columns without errors
- [ ] set_weights() works with both array and string arguments
- [ ] Deprecation warning shown for set_weight_col()

🤖 Generated with Claude Code