### PR TITLE
Fix silent 0.0 from weighted sum when index is not default

### DIFF
--- a/changelog.d/fix-weights-index-alignment.fixed.md
+++ b/changelog.d/fix-weights-index-alignment.fixed.md
@@ -1,0 +1,1 @@
+Aligned weights Series to `self.index` in `MicroSeries.set_weights` and `MicroDataFrame.set_weights` so weighted operations (`.sum()`, `.weight()`, `.top_x_pct_share()`, `.gini()`, etc.) return correct values when the data uses a non-default index. Previously they silently returned `0.0`.

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -305,7 +305,11 @@ class MicroDataFrame(pd.DataFrame):
 
         if isinstance(weights, str):
             self.weights_col = weights
-            self.weights = pd.Series(self[weights], dtype=float)
+            self.weights = pd.Series(
+                np.asarray(self[weights]),
+                index=self.index,
+                dtype=float,
+            )
             self._link_all_weights()
         elif weights is not None:
             if len(weights) != len(self):
@@ -314,9 +318,18 @@ class MicroDataFrame(pd.DataFrame):
                     f"length of DataFrame ({len(self)})."
                 )
             self.weights_col = None
+            # Align weights to self.index. Without this, weighted ops
+            # (self[col].multiply(self.weights) in .sum()) align on
+            # label, so any non-default index silently produces all-NaN
+            # and aggregations collapse to 0. If a Series is passed in,
+            # strip its index so we position-align to self.index.
+            if isinstance(weights, pd.Series):
+                weights = weights.values
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UserWarning)
-                self.weights = pd.Series(weights, dtype=float)
+                self.weights = pd.Series(
+                    np.asarray(weights), index=self.index, dtype=float
+                )
             self._link_all_weights()
 
     def set_weight_col(self, column: str, preserve_old: Optional[bool] = False) -> None:

--- a/microdf/microseries.py
+++ b/microdf/microseries.py
@@ -96,7 +96,11 @@ class MicroSeries(pd.Series):
         """
         if weights is None:
             if len(self) > 0:
-                self.weights = pd.Series(np.ones_like(self._values), dtype=float)
+                self.weights = pd.Series(
+                    np.ones_like(self._values),
+                    index=self.index,
+                    dtype=float,
+                )
         else:
             if len(weights) != len(self):
                 raise ValueError(
@@ -107,7 +111,14 @@ class MicroSeries(pd.Series):
             if preserve_old and self.weights is not None:
                 self["old_weights"] = self.weights
 
-            self.weights = pd.Series(weights, dtype=float)
+            # Align weights to self.index so element-wise operations such
+            # as self.multiply(self.weights) (used by .sum(), .weight())
+            # don't silently produce all-NaN when the caller uses a
+            # non-default index. If a pandas Series is passed in, strip
+            # its index first so we position-align rather than label-align.
+            if isinstance(weights, pd.Series):
+                weights = weights.values
+            self.weights = pd.Series(np.asarray(weights), index=self.index, dtype=float)
 
     def nullify_weights(self) -> None:
         """Set all weights to 1, effectively making the Series unweighted.

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -445,6 +445,43 @@ def test_mean_no_warning() -> None:
         assert len(user_warnings) == 0
 
 
+def test_sum_with_non_default_index() -> None:
+    """Weighted sum must not silently return 0 with a non-default index.
+
+    Regression test for the bug where ``set_weights`` stored the weights
+    Series with a default ``RangeIndex`` regardless of ``self.index``.
+    Element-wise ops like ``self.multiply(self.weights)`` then aligned on
+    label, producing all-NaN and a silent ``0.0`` from ``.sum()`` while
+    ``.mean()`` (which uses a positional ndarray) stayed correct.
+    """
+    # MicroSeries with custom integer index.
+    s = mdf.MicroSeries([1, 2, 3], index=[100, 200, 300], weights=[10, 20, 30])
+    assert s.sum() == 140.0
+    assert s.weights.index.tolist() == [100, 200, 300]
+
+    # MicroDataFrame with custom integer index.
+    df = mdf.MicroDataFrame(
+        {"x": [1, 2, 3]}, index=[100, 200, 300], weights=[10, 20, 30]
+    )
+    assert df.x.sum() == 140.0
+    assert df.weights.index.tolist() == [100, 200, 300]
+
+    # MicroDataFrame with string index + set_weights via column name.
+    df2 = mdf.MicroDataFrame(
+        {"x": [1, 2, 3], "w": [10, 20, 30]},
+        index=["a", "b", "c"],
+    )
+    df2.set_weights("w")
+    assert df2.x.sum() == 140.0
+    assert df2.weights.index.tolist() == ["a", "b", "c"]
+
+    # Passing a Series with its own index should position-align, not
+    # label-align, so sum does not depend on accidental index alignment.
+    df3 = mdf.MicroDataFrame({"x": [1, 2, 3]}, index=[100, 200, 300])
+    df3.set_weights(pd.Series([10, 20, 30], index=[0, 1, 2]))
+    assert df3.x.sum() == 140.0
+
+
 def test_repr_no_warning() -> None:
     """Internal .values usage in __repr__ should NOT emit a warning."""
     ms = mdf.MicroSeries([1, 2, 3], weights=[4, 5, 6])


### PR DESCRIPTION
## Summary

`MicroSeries.set_weights` and `MicroDataFrame.set_weights` built the weights Series with a default `RangeIndex` regardless of `self.index`. Element-wise ops like `self.multiply(self.weights)` (used by `.sum()` / `.weight()`) then aligned on label, producing all-NaN and a silent `0.0` from `.sum()` whenever the caller used a non-default index. `.mean()` kept working because it reads a positional ndarray — so sums were 0 but means were correct, making the bug extremely hard to notice on survey data.

This PR aligns the weights Series to `self.index` and strips any incoming Series index so we position-align rather than label-align.

## Reproduction

```python
import microdf as mdf

s = mdf.MicroSeries([1, 2, 3], index=[100, 200, 300], weights=[10, 20, 30])
s.sum()  # was 0.0, now 140.0

df = mdf.MicroDataFrame({"x": [1, 2, 3]}, index=[100, 200, 300], weights=[10, 20, 30])
df.x.sum()  # was 0.0, now 140.0
```

Blast radius: any code that reads CSV/Parquet with a domain index (household ID, year, state) or filters a MicroDataFrame and then calls `.sum()`, `.top_x_pct_share()`, `.gini()`, `.poverty_gap()`, etc.

Note: this is distinct from #262 / #263 (which fixes `sum(axis=...)` for `MicroDataFrame`). That PR can still land independently; they touch different lines.

## Test plan

- [x] Existing 51 tests still pass
- [x] New `test_sum_with_non_default_index` covers:
  - MicroSeries with custom integer index
  - MicroDataFrame with custom integer index
  - MicroDataFrame with string index + `set_weights("w")` via column name
  - `set_weights` with a Series whose index differs from `self.index`
- [x] `make format` / `make lint` pass