### PR TITLE
Fix merge() to propagate weights per surviving row

### DIFF
--- a/changelog.d/fix-merge-row-align.fixed.md
+++ b/changelog.d/fix-merge-row-align.fixed.md
@@ -1,0 +1,1 @@
+Fixed `MicroDataFrame.merge` raising `ValueError` on any row-changing join. The implementation now attaches the left-side weights as a temporary column before the merge so pandas propagates them onto each surviving output row (handling inner filtering, left-with-missing, many-to-many duplication, and outer joins). Right-only outer rows default to a 0 weight.

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -594,7 +594,17 @@ class MicroDataFrame(pd.DataFrame):
         :param validate: If specified, checks if merge is of specified type.
         :return: MicroDataFrame with merged data.
         """
-        res = super().merge(
+        # Attach the left weights as a temporary column so pandas' merge
+        # propagates them onto every surviving output row (including
+        # many-to-many row duplications, inner-join filtering, and
+        # left-with-missing NaNs). We then strip the column back off.
+        tmp = "__microdf_weights__"
+        # Avoid clobbering if this exact name is already used.
+        while tmp in self.columns or tmp in right.columns:
+            tmp += "_"
+        left_df = pd.DataFrame(self).copy()
+        left_df[tmp] = np.asarray(self.weights.values, dtype=float)
+        res = left_df.merge(
             right,
             how=how,
             on=on,
@@ -608,11 +618,17 @@ class MicroDataFrame(pd.DataFrame):
             indicator=indicator,
             validate=validate,
         )
-
-        # For inner join, both dataframes must have the same weights on
-        # matching rows. For now, we'll use the left dataframe's weights.
-        # This is a simplification and may need more sophisticated handling
-        return MicroDataFrame(res, weights=self.weights)
+        # Pull out the propagated weights. Rows with no left match in a
+        # right/outer join get NaN weight — fill with 0 so they don't
+        # poison later aggregations (a user who needs a different
+        # convention can override afterwards).
+        merged_weights = res[tmp].fillna(0).to_numpy(dtype=float)
+        res = res.drop(columns=[tmp])
+        out = MicroDataFrame(res, weights=merged_weights)
+        # Ensure the weights Series aligns with res.index regardless of
+        # the default-RangeIndex behavior of set_weights.
+        out.weights = pd.Series(merged_weights, index=out.index, dtype=float)
+        return out
 
     def __getattr__(self, name):
         """Allow accessing columns as attributes (e.g., df.column_name).

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -534,3 +534,50 @@ def test_drop_inplace_aligns_weights() -> None:
     df = mdf.MicroDataFrame({"x": [1, 2, 3, 4]}, weights=[10, 20, 30, 40])
     df.drop(labels=[0, 1], inplace=True)
     assert df.x.sum() == 250
+
+
+def test_merge_preserves_weights_per_surviving_row() -> None:
+    """Regression: merge must propagate weights onto the merged rows.
+
+    Previously the implementation passed ``self.weights`` straight to the
+    MicroDataFrame constructor, so any merge that changed row count
+    (inner filtering, left-with-missing, many-to-many, outer) raised
+    ``ValueError: Length of weights (N) does not match length of
+    DataFrame (M)``.
+    """
+    # Inner join filters rows.
+    left = mdf.MicroDataFrame(
+        {"k": [1, 2, 3, 4], "v": [10, 20, 30, 40]}, weights=[1, 2, 3, 4]
+    )
+    right = pd.DataFrame({"k": [2, 4], "w": [20, 40]})
+    res = left.merge(right, on="k")
+    assert len(res) == 2
+    # k=2 carries weight 2; k=4 carries weight 4.
+    np.testing.assert_array_equal(sorted(res.weights.values), [2.0, 4.0])
+    assert res.v.sum() == 2 * 20 + 4 * 40
+
+    # Left join with missing from right.
+    left = mdf.MicroDataFrame(
+        {"k": [1, 2, 3, 4], "v": [10, 20, 30, 40]}, weights=[1, 2, 3, 4]
+    )
+    right = pd.DataFrame({"k": [2, 4], "w": [100, 200]})
+    res = left.merge(right, on="k", how="left")
+    assert len(res) == 4
+    assert res.v.sum() == 300  # 1*10 + 2*20 + 3*30 + 4*40
+
+    # Many-to-many duplicates left rows; the same weight should ride
+    # along on each duplicate.
+    left = mdf.MicroDataFrame({"k": [1, 2], "v": [10, 20]}, weights=[5, 7])
+    right = pd.DataFrame({"k": [1, 1, 2], "w": [100, 200, 300]})
+    res = left.merge(right, on="k")
+    assert len(res) == 3
+    # v=10 weighted 5 appears twice, v=20 weighted 7 appears once.
+    assert res.v.sum() == 10 * 5 + 10 * 5 + 20 * 7
+
+    # Outer join: right-only rows have no left weight. We default to 0
+    # so they don't silently poison downstream aggregations.
+    left = mdf.MicroDataFrame({"k": [1, 2], "v": [10, 20]}, weights=[1, 2])
+    right = pd.DataFrame({"k": [2, 3], "w": [20, 30]})
+    res = left.merge(right, on="k", how="outer")
+    # k=1 -> weight 1, k=2 -> weight 2, k=3 -> weight 0 (right-only).
+    assert sorted(res.weights.values) == [0.0, 1.0, 2.0]


### PR DESCRIPTION
## Summary

`MicroDataFrame.merge()` called `super().merge()` then re-attached `self.weights` wholesale, so any row-changing join (inner filtering, left-with-missing, many-to-many, outer) raised `ValueError: Length of weights (N) does not match length of DataFrame (M)` — effectively defeating the method's purpose.

Fix: attach `self.weights` as a temporary column on the left before the merge so pandas propagates the right weight onto each surviving output row (including duplicated rows from many-to-many joins). Right-only outer rows default to a 0 weight.

## Reproduction

```python
import microdf as mdf
import pandas as pd

left  = mdf.MicroDataFrame({"k":[1,2,3,4], "v":[10,20,30,40]}, weights=[1,2,3,4])
right = pd.DataFrame({"k":[2,4], "w":[20,40]})
left.merge(right, on="k")   # used to raise ValueError
```

## Test plan

- [x] Existing 51 tests still pass
- [x] New `test_merge_preserves_weights_per_surviving_row` covers:
  - Inner join (row filtering)
  - Left join with missing
  - Many-to-many duplication (weight rides along on each duplicate)
  - Outer join (right-only rows default to weight 0)