### PR TITLE
Don't leak __tmp_weights column out of groupby

### DIFF
--- a/changelog.d/fix-groupby-tmp-weights-leak.fixed.md
+++ b/changelog.d/fix-groupby-tmp-weights-leak.fixed.md
@@ -1,0 +1,1 @@
+Fixed `MicroDataFrame.groupby` leaking a `__tmp_weights` column onto the caller. Previously, calling `df.groupby(...)` permanently added the weight column to `df.columns`, so any subsequent `df.sum()` or iteration included it. The implementation now stages the weights on a copy before calling `super().groupby`, leaving `self` untouched.

--- a/microdf/microdataframe.py
+++ b/microdf/microdataframe.py
@@ -660,10 +660,16 @@ class MicroDataFrame(pd.DataFrame):
         return: DataFrameGroupBy object with columns using weights
         rtype: DataFrameGroupBy
         """
-        self["__tmp_weights"] = self.weights
-        gb = super().groupby(by, *args, **kwargs)
+        # Build the groupby on a *copy* that carries a ``__tmp_weights``
+        # column. We used to set this column on ``self`` directly, which
+        # permanently leaked the weight column onto the caller's
+        # DataFrame — any later ``df.sum()`` or ``list(df.columns)``
+        # would then include it.
+        staged = pd.DataFrame(self).copy()
+        staged["__tmp_weights"] = np.asarray(self.weights.values, dtype=float)
+        gb = staged.groupby(by, *args, **kwargs)
         weights = copy.deepcopy(gb["__tmp_weights"])
-        for col in self.columns:  # df.groupby(...)[col]s use weights
+        for col in staged.columns:  # df.groupby(...)[col]s use weights
             res = gb[col]
             res.__class__ = MicroSeriesGroupBy
             res._init()

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -581,3 +581,32 @@ def test_merge_preserves_weights_per_surviving_row() -> None:
     res = left.merge(right, on="k", how="outer")
     # k=1 -> weight 1, k=2 -> weight 2, k=3 -> weight 0 (right-only).
     assert sorted(res.weights.values) == [0.0, 1.0, 2.0]
+
+
+def test_groupby_does_not_leak_tmp_weights_column() -> None:
+    """Regression: groupby used to mutate self by adding __tmp_weights.
+
+    Previously, ``MicroDataFrame.groupby`` set ``self["__tmp_weights"]``
+    and never cleaned it up, so ``df.columns`` afterwards included the
+    weight column and any later ``df.sum()`` or iteration over columns
+    picked it up as data.
+    """
+    df = mdf.MicroDataFrame({"g": ["a", "a", "b"], "v": [1, 2, 3]}, weights=[1, 2, 3])
+    original_cols = list(df.columns)
+    _ = df.groupby("g").sum()
+    assert list(df.columns) == original_cols
+    assert "__tmp_weights" not in df.columns
+
+    # Groupby by a list of columns should also not leak.
+    df2 = mdf.MicroDataFrame(
+        {"g1": ["a", "a", "b"], "g2": [1, 1, 2], "v": [1, 2, 3]},
+        weights=[1, 2, 3],
+    )
+    orig2 = list(df2.columns)
+    _ = df2.groupby(["g1", "g2"]).v.sum()
+    assert list(df2.columns) == orig2
+
+    # Weighted aggregation is still correct after the fix.
+    result = df.groupby("g").v.sum()
+    assert result["a"] == 1 * 1 + 2 * 2
+    assert result["b"] == 3 * 3


### PR DESCRIPTION
## Summary

`MicroDataFrame.groupby` used to do `self["__tmp_weights"] = self.weights` and never clean it up, so after a single `df.groupby(...)` call the caller's DataFrame permanently carried the weight column. Any later `df.sum()` or iteration over columns then picked it up as data.

Fix: stage the weights onto a copy before calling `super().groupby()` rather than mutating `self`. All existing groupby plumbing (`_weights_groupby`, per-column `MicroSeriesGroupBy`) keeps working.

## Reproduction

```python
import microdf as mdf

df = mdf.MicroDataFrame({"g": ["a", "a", "b"], "v": [1, 2, 3]}, weights=[1, 2, 3])
_ = df.groupby("g").sum()
list(df.columns)   # was ['g', 'v', '__tmp_weights'], now ['g', 'v']
```

## Test plan

- [x] Existing 51 tests still pass
- [x] New `test_groupby_does_not_leak_tmp_weights_column` covers single-column and list-of-columns groupbys and verifies the weighted aggregation result stays correct.