### PR TITLE
Skip zero-weight rows in MicroSeries.quantile

### DIFF
--- a/changelog.d/fix-quantile-zero-weight-first-row.fixed.md
+++ b/changelog.d/fix-quantile-zero-weight-first-row.fixed.md
@@ -1,0 +1,1 @@
+Fixed `MicroSeries.quantile` returning values with weight 0. Previously, when the first (or an internal) sorted element had zero weight, the inverse-CDF search still picked it (e.g. `MicroSeries([10, 20, 30], weights=[0, 1, 1]).quantile(0)` returned 10 instead of 20). Zero-weight rows are now dropped before computing the CDF; an all-zero-weight series returns NaN.

--- a/microdf/microseries.py
+++ b/microdf/microseries.py
@@ -191,6 +191,20 @@ class MicroSeries(pd.Series):
         assert np.all(quantiles >= 0) and np.all(quantiles <= 1), (
             "quantiles should be in [0, 1]"
         )
+        # Drop zero-weight rows before sorting. Without this, q=0 (and
+        # internal plateaus of zero weight) picked a value with 0 weight
+        # that should have been skipped by the inverse CDF. E.g.
+        # MicroSeries([10, 20, 30], weights=[0, 1, 1]).quantile(0)
+        # returned 10 instead of 20.
+        nonzero = sample_weight > 0
+        if not nonzero.any():
+            return (
+                np.nan
+                if np.array(q).shape == ()
+                else pd.Series(np.full(len(quantiles), np.nan), index=quantiles)
+            )
+        values = values[nonzero]
+        sample_weight = sample_weight[nonzero]
         sorter = np.argsort(values)
         values = values[sorter]
         sample_weight = sample_weight[sorter]

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -610,3 +610,32 @@ def test_groupby_does_not_leak_tmp_weights_column() -> None:
     result = df.groupby("g").v.sum()
     assert result["a"] == 1 * 1 + 2 * 2
     assert result["b"] == 3 * 3
+
+
+def test_quantile_skips_zero_weight_rows() -> None:
+    """Regression: quantile(0) shouldn't pick a zero-weight element.
+
+    Previously, ``np.searchsorted(cumsum_norm, 0, side='left')`` returned
+    0 even when that first sorted element had zero weight, so
+    ``MicroSeries([10, 20, 30], weights=[0, 1, 1]).quantile(0)`` returned
+    10 instead of 20. The fix drops zero-weight rows before computing
+    the CDF.
+    """
+    s = mdf.MicroSeries([10, 20, 30], weights=[0, 1, 1])
+    assert s.quantile(0.0) == 20
+    assert s.quantile(0.5) == 20
+    assert s.quantile(1.0) == 30
+
+    # Internal plateau of zero weight.
+    s = mdf.MicroSeries([10, 20, 30, 40], weights=[1, 0, 1, 1])
+    assert s.quantile(0.0) == 10
+    # Post-filter values [10, 30, 40] with equal weights -> cum=[.33,.67,1].
+    # 0.4 -> smallest cum >= 0.4 is index 1 -> value 30.
+    assert s.quantile(0.4) == 30
+    # The zero-weight value (20) should never be selected.
+    for q in np.linspace(0, 1, 21):
+        assert s.quantile(q) != 20
+
+    # All zero weights -> NaN (defined behaviour).
+    s = mdf.MicroSeries([10, 20, 30], weights=[0, 0, 0])
+    assert np.isnan(s.quantile(0.5))


### PR DESCRIPTION
## Summary

`MicroSeries.quantile` could select a zero-weight element because `np.searchsorted(cumsum_norm, 0, side='left')` always returns 0, and the same class of bug fired at internal plateaus of zero weight. The fix drops zero-weight rows before sorting and computing the CDF; an all-zero-weight series returns NaN.

## Reproduction

```python
import microdf as mdf

MicroSeries([10, 20, 30], weights=[0, 1, 1]).quantile(0.0)  # was 10, now 20
```

## Test plan

- [x] Existing 51 tests still pass
- [x] New `test_quantile_skips_zero_weight_rows` covers:
  - Zero-weight first row
  - Internal zero-weight plateau (the zero-weight value must never be selected across q in [0, 1])
  - All zero weights → NaN