### PR TITLE
Make MicroSeries.count() skip NaN by default

### DIFF
--- a/changelog.d/fix-count-nan-skipna.fixed.md
+++ b/changelog.d/fix-count-nan-skipna.fixed.md
@@ -1,0 +1,1 @@
+Fixed `MicroSeries.count()` silently including NaN-row weights, contrary to pandas semantics. `count()` now skips NaN by default (matching `pandas.Series.count`) and accepts `skipna=False` to recover the old behaviour.

--- a/microdf/microseries.py
+++ b/microdf/microseries.py
@@ -177,12 +177,22 @@ class MicroSeries(pd.Series):
         return self.multiply(self.weights).sum()
 
     @scalar_function
-    def count(self) -> float:
+    def count(self, skipna: bool = True) -> float:
         """Calculates the weighted count of the MicroSeries.
 
+        By default skips NaN values (matching pandas ``Series.count``).
+
+        :param skipna: Exclude NaN values (default True). If False, the
+            weighted count of every row is returned.
+        :type skipna: bool
         :returns: The weighted count.
+        :rtype: float
         """
-        return self.weights.sum()
+        weights = np.asarray(self.weights.values, dtype=float)
+        if not skipna:
+            return float(weights.sum())
+        mask = ~pd.isna(self._values)
+        return float(weights[mask].sum())
 
     @scalar_function
     def mean(self, skipna: bool = True) -> float:

--- a/microdf/tests/test_microseries_dataframe.py
+++ b/microdf/tests/test_microseries_dataframe.py
@@ -768,3 +768,24 @@ def test_cov_corr_warn_when_fallthrough() -> None:
         _ = s1.corr(s2)
         msgs = [str(x.message) for x in w if issubclass(x.category, UserWarning)]
         assert any("unweighted" in m.lower() for m in msgs)
+
+
+def test_count_skips_nan_by_default() -> None:
+    """Regression: ``count()`` included NaN-row weight, contrary to pandas.
+
+    Pandas ``Series.count`` skips NaN; MicroSeries returned the full
+    weight sum regardless. The fix matches pandas semantics and adds a
+    ``skipna`` kwarg so callers can opt out.
+    """
+    s = mdf.MicroSeries([1.0, np.nan, 3.0], weights=[10, 20, 30])
+    assert s.count() == 40.0
+    assert s.count(skipna=True) == 40.0
+    assert s.count(skipna=False) == 60.0
+
+    # No NaN: skipna is a no-op.
+    assert mdf.MicroSeries([1, 2, 3], weights=[2, 3, 4]).count() == 9.0
+
+    # All NaN: count skips everything.
+    all_nan = mdf.MicroSeries([np.nan] * 3, weights=[1, 2, 3])
+    assert all_nan.count() == 0.0
+    assert all_nan.count(skipna=False) == 6.0


### PR DESCRIPTION
## Summary

`MicroSeries.count()` always returned `self.weights.sum()`, ignoring NaN values — contradicting both the docstring and pandas' `Series.count` semantics.

## Reproduction

```python
import microdf as mdf, numpy as np

mdf.MicroSeries([1.0, np.nan, 3.0], weights=[10, 20, 30]).count()
# was 60.0 (included the NaN row's weight), now 40.0
```

## Fix

Mask out NaN values by default. Accept `skipna=False` to recover the old behaviour.

## Test plan

- [x] Existing 51 tests still pass (including `test_poverty_count`, which depends on `count()`)
- [x] New `test_count_skips_nan_by_default` covers NaN present, no NaN, all NaN, and both `skipna` values.