### PR TITLE
Remove dead weighted_function decorator

### DIFF
--- a/changelog.d/fix-remove-dead-weighted-decorator.removed.md
+++ b/changelog.d/fix-remove-dead-weighted-decorator.removed.md
@@ -1,0 +1,1 @@
+Removed the `MicroSeries.weighted_function` decorator that wrapped `scalar_function` / `vector_function` at class-body execution (not the decorated methods), so the `ZeroDivisionError -> np.NaN` fallback was never reached at runtime. It also referenced `np.NaN`, which was removed in numpy 2.0, so any legitimate trigger would have raised `AttributeError`.

--- a/microdf/microseries.py
+++ b/microdf/microseries.py
@@ -64,23 +64,13 @@ class MicroSeries(pd.Series):
         )
         return super().to_numpy(*args, **kwargs)
 
-    def weighted_function(fn: Callable) -> Callable:
-        @wraps(fn)
-        def safe_fn(*args, **kwargs):
-            try:
-                return fn(*args, **kwargs)
-            except ZeroDivisionError:
-                return np.NaN
-
-        return safe_fn
-
-    @weighted_function
     def scalar_function(fn: Callable) -> Callable:
+        """Decorator marking ``fn`` as returning a scalar (float)."""
         fn._rtype = float
         return fn
 
-    @weighted_function
     def vector_function(fn: Callable) -> Callable:
+        """Decorator marking ``fn`` as returning a pandas Series."""
         fn._rtype = pd.Series
         return fn
 


### PR DESCRIPTION
## Summary

`MicroSeries.weighted_function` wrapped `scalar_function` / `vector_function` *at class-body execution*, not the scalar/vector methods they produce — so the `try/except ZeroDivisionError -> np.NaN` fallback was never reachable at runtime. It also referenced `np.NaN`, which was removed in numpy 2.0, so any legitimate trigger would have raised `AttributeError`.

The decorator is dead code. Delete it; `scalar_function` and `vector_function` remain as the straightforward `_rtype` markers they actually need to be.

## Test plan

- [x] All 51 existing tests still pass.
- [x] No other references to `weighted_function` in the codebase.