### PR TITLE
Point CONTRIBUTING.md at the shared PolicyEngine guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,30 @@
-## Updating the code
+# Contributing to microdf
 
-Please make sure that introduced changes are consistent with the testing api and add additional tests if relevant.
+See the [shared PolicyEngine contribution guide](https://github.com/PolicyEngine/.github/blob/main/CONTRIBUTING.md) for cross-repo conventions (towncrier changelog fragments, `uv run`, PR description format, anti-patterns). This file covers microdf specifics.
 
-## Updating the versioning
+## Commands
 
-Please add to `changelog.yaml` and then run `make changelog` before committing the results ONCE in this PR.
+```bash
+make install         # install deps
+make format          # format (required)
+make test            # test suite
+uv run pytest microdf/tests/path/to/test.py::test_name -v
+```
+
+Default branch: `main`.
+
+## What lives here
+
+microdf provides weighted-microdata primitives used throughout PolicyEngine:
+
+- `MicroSeries` — weighted pandas Series with weighted quantiles, means, medians, ginis
+- `MicroDataFrame` — weighted DataFrame of `MicroSeries`
+- `generic` — weight-aware reductions, groupby helpers
+
+Consumers: `policyengine-core`, every country package, `policyengine.py`, `policyengine-api`. API stability matters — think twice before changing public signatures.
+
+## Repo-specific anti-patterns
+
+- **Don't** change weighted-statistic semantics without a migration plan. Downstream analyses depend on exact numerical output.
+- **Don't** introduce heavyweight dependencies — microdf is imported by every PolicyEngine Python package; bloat compounds.
+- **Don't** hand-roll weighted statistics; extend the existing `MicroSeries` / `MicroDataFrame` APIs so new behaviour is discoverable.

--- a/changelog.d/docs-towncrier-contributing.changed.md
+++ b/changelog.d/docs-towncrier-contributing.changed.md
@@ -1,0 +1,1 @@
+Point CONTRIBUTING.md at the shared PolicyEngine contribution guide (https://github.com/PolicyEngine/.github) and trim the per-repo file to commands, repo-specific conventions, and anti-patterns. Removes the stale `changelog_entry.yaml` / `make changelog` instructions.


### PR DESCRIPTION
## Summary

Replaces the per-repo CONTRIBUTING.md with a pointer to the new shared guide at https://github.com/PolicyEngine/.github/blob/main/CONTRIBUTING.md (proposed in PolicyEngine/.github#3), keeping only the repo-specific bits here: commands, key conventions, and repo-level anti-patterns.

Part of a sweep across PolicyEngine repos so agents and human contributors alike land on one authoritative cross-repo guide for changelog format, `uv run`, branching, PR etiquette, and anti-patterns, without each repo's copy drifting out of sync.

## Test plan

- [x] Docs only, no code touched
- [ ] Shared guide at `PolicyEngine/.github#3` lands (or is already merged) so the link resolves
- [ ] CI passes
